### PR TITLE
support secure survey with password and change structure of code to use MVC pattern

### DIFF
--- a/backend/components/helpers/mongodb.js
+++ b/backend/components/helpers/mongodb.js
@@ -25,12 +25,8 @@ function findWithProjector(filters, collection, projector, sort) {
     return _find(filters, collection, projector, sort, 0 , 0);
 }
 
-function findWithPaging(filters, collection, sort, limit , skip){
-    return _find(filters, collection, {
-        projection: {
-            _id: 0
-        }
-    }, sort, limit, skip); 
+function findWithPaging(filters, collection, projector, sort, limit , skip){
+    return _find(filters, collection, {_id: 0, ...projector}, sort, limit, skip); 
 }
 
 function find(filters, collection, sort) {
@@ -42,12 +38,12 @@ function find(filters, collection, sort) {
 }
 
 function _find(filters, collection, projector, sort, limit, skip) {
-    console.log("limit: " + limit + " skip: " + skip);
+    console.log("limit: " + limit + " skip: " + skip + " projector: " + JSON.stringify(projector));
     return new promise((resolve, reject) => {
         getPoolConnection().then(db => {
                 logger.debug("mongodb connected");
                 db.db(appConf.MONGODB_dbname)
-                    .collection(collection).find(filters, projector).skip(skip).limit(limit).sort(sort).toArray(function (err, results) {
+                    .collection(collection).find(filters).project(projector).skip(skip).limit(limit).sort(sort).toArray(function (err, results) {
                         if (err) {
                             logger.error('Error occurred while querying: ' + err);
                             reject(err);
@@ -138,7 +134,7 @@ function update(filters, data, collection) {
                         } else {
                             logger.debug('updated record: ' + JSON.stringify(result));
                             db.close();
-                            resolve(true);
+                            resolve(result);
                         }
                     })
             })
@@ -164,7 +160,7 @@ function remove(filters, justOne, collection) {
                             reject(err);
                         } else {
                             console.log(results);
-                            logger.debug('results: ' + JSON.stringify(results));
+                            logger.debug('delete result: ' + JSON.stringify(results));
                             db.close();
                             resolve(results);
                         }

--- a/backend/model/v2/result.js
+++ b/backend/model/v2/result.js
@@ -1,0 +1,70 @@
+// MIT License
+
+// Copyright 2019-present, Digital Government Development Agency (Public Organization) 
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+"use strict";
+
+const {
+    logger
+} = require('../../commons/logger');
+const appConf = require('../../config/production.conf');
+const promise = require('promise');
+const mongodb = require('../../components/helpers/mongodb');
+
+function find(filter, projection, sort) {
+    return mongodb.findWithProjector(filter, appConf.surveyCollections.result, projection, sort);
+}
+
+function findOneAndReplace(filter, result) {
+
+    const data = {
+        surveyid: result.surveyid,
+        resultid: result.resultid,
+        version: result.version,
+        userid: result.userid,
+        result: result.result,
+        created_at: result.created_at,
+        modified_at: result.modified_at,
+    }
+
+    return mongodb.insert(filter, data, appConf.surveyCollections.result);
+}
+
+function findWithPaging(filter, projector, sort, page_size, page) {
+    return mongodb.findWithPaging(filter, appConf.surveyCollections.result, projector, sort, page_size, page);
+}
+
+function count(filter) {
+    return mongodb.count(filter, appConf.surveyCollections.result)
+        .then(r => {
+            return Promise.resolve(r);
+        })
+        .catch(err => {
+            console.log("count error: " + err);
+            return Promise.resolve(0);
+        });
+}
+
+module.exports = {
+    find,
+    findOneAndReplace,
+    findWithPaging,
+    count,
+}

--- a/backend/model/v2/survey.js
+++ b/backend/model/v2/survey.js
@@ -1,0 +1,81 @@
+// MIT License
+
+// Copyright 2019-present, Digital Government Development Agency (Public Organization) 
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+"use strict";
+
+const {
+    logger
+} = require('../../commons/logger');
+const appConf = require('../../config/production.conf');
+const promise = require('promise');
+const mongodb = require('../../components/helpers/mongodb');
+
+function find(filter, projection, sort) {
+    return mongodb.findWithProjector(filter, appConf.surveyCollections.survey, projection, sort);
+}
+
+function findWithPaging(filter, projector, sort, page_size, page) {
+    return mongodb.findWithPaging(filter, appConf.surveyCollections.survey, projector, sort, page_size, page);
+}
+
+function findOneAndReplace(filter, survey) {
+    const data = {
+        userid: survey.userid,
+        name: survey.name,
+        surveyid: survey.surveyid,
+        version: survey.version,
+        password: survey.password,
+        password_enable: survey.password_enable,
+        pages: survey.pages,
+        created_at: survey.created_at,
+        modified_at: survey.created_at,
+    }
+
+    return mongodb.insert(filter, data, appConf.surveyCollections.survey);
+}
+
+function count(filter) {
+    return mongodb.count(filter, appConf.surveyCollections.survey)
+        .then(r => {
+            return Promise.resolve(r);
+        })
+        .catch(err => {
+            console.log("count error: " + err);
+            return Promise.resolve(0);
+        });
+}
+
+function updateOne(filter, data) {
+    return mongodb.update(filter, data, appConf.surveyCollections.survey);
+}
+
+function removeOne(filter) {
+    return mongodb.remove(filter, true, appConf.surveyCollections.survey);
+}
+
+module.exports = {
+    find,
+    findWithPaging,
+    findOneAndReplace,
+    count,
+    updateOne,
+    removeOne
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "node bin/www/server.js",
     "build": "react-scripts build",
-    "test": "jest --watchAll --coverage",
+    "test": "jest --watchAll --coverage -- test/v2/",
     "eject": "react-scripts eject"
   },
   "proxy": "http://localhost:3001",

--- a/backend/test/mock.js
+++ b/backend/test/mock.js
@@ -1,13 +1,34 @@
 mockRequest = (sessionData, body) => ({
-    session: { data: sessionData },
+    session: {
+        data: sessionData
+    },
     body: body,
 });
-  
+
 mockResponse = () => {
     const res = {};
-        res.status = jest.fn().mockReturnValue(res);
-        res.json = jest.fn().mockReturnValue(res);
-        return res;
+    res.s = jest.fn()
+    res.j = jest.fn()
+
+    res.status = (status) => {
+        if (status === undefined) {
+            return res.s();
+        } else {
+            res.s.mockReturnValue(status);
+            return res;
+        }
+    }
+
+    res.json = (data) => {
+        if (data === undefined) {
+            return res.j();
+        } else {
+            res.j.mockReturnValue(data);
+            return res;
+        }
+    }
+
+    return res;
 };
 
 module.exports = {

--- a/backend/test/v2/admin/result.test.js
+++ b/backend/test/v2/admin/result.test.js
@@ -1,0 +1,85 @@
+const path = require('path');
+global.appRoot = path.resolve(__dirname);
+const appConf = require('../../../config/production.conf');
+const mock = require("../../mock");
+const resultApi = require("../../..//components/v2/admin/survey");
+
+describe("save a resutl", () => {
+
+    let req = mock.mockRequest({}, {
+        surveyid: "1",
+        resultid: "1",
+        version: "1",
+        userid: "24",
+        result: {
+            ans1: "aa",
+            ans2: "bb"
+        },
+        created_at: new Date(),
+        modified_at: new Date(),
+    });
+
+    let res = mock.mockResponse();
+
+    test("save result", () => {
+        return resultApi.saveResult(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+            });
+    });
+});
+
+describe("search a result", () => {
+
+    let req = mock.mockRequest({}, {});
+    req.params = {
+        resultId: '1'
+    };
+
+    let res = mock.mockResponse();
+
+    test("get a result with id = 1", () => {
+        return resultApi.getResultById(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+                const j = res.json();
+                expect(j.data[0].resultid).toBe("1");
+                expect(j.data[0].surveyid).toBe("1");
+                expect(j.data[0].version).toBe("1");
+                expect(j.data[0].userid).toBe("24");
+                expect(j.data[0].result.ans1).toBe("aa");
+                expect(j.data[0].result.ans2).toBe("bb");
+            });
+    });
+});
+
+describe("search all result by survey id = 1", () => {
+
+    let req = mock.mockRequest({}, {});
+
+    req.params = {
+        surveyId: "1"
+    };
+
+    req.query = {
+        uid: "24",
+        v: "1",
+        page: 1,
+        per_page: 1
+    };
+
+    let res = mock.mockResponse();
+
+    test("search all result by with surveyid = 1, userid = 1", () => {
+        return resultApi.getAllResultsBySurveyId(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+                let r = res.json();
+                console.log(r);
+                expect(r.per_page).toBe(req.query.per_page);
+                expect(r.page).toBe(req.query.page);
+                expect(r.total !== 'undefined').toBe(true);
+            });
+    });
+
+});

--- a/backend/test/v2/admin/survey.test.js
+++ b/backend/test/v2/admin/survey.test.js
@@ -1,0 +1,163 @@
+const path = require('path');
+global.appRoot = path.resolve(__dirname);
+const appConf = require('../../../config/production.conf');
+const mock = require("../../mock");
+const surveyApi = require("../../..//components/v2/admin/survey");
+
+
+describe("create survey", () => {
+
+    let req = mock.mockRequest({}, {
+        userid: "24",
+        surveyid: "1",
+        version: "1",
+        name: "test",
+        password: "1234",
+        pages: {
+            test: "aa",
+            test2: "bb",
+        },
+        created_at: new Date(),
+        modified_at: new Date(),
+    });
+
+    let res = mock.mockResponse();
+
+    test("create survey", () => {
+        return surveyApi.createEmptySurvey(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+            });
+    });
+});
+
+describe("save survey", () => {
+
+    let req = mock.mockRequest({}, {
+        userid: "24",
+        surveyid: "1",
+        version: "1",
+        name: "test",
+        password: "1234",
+        pages: {
+            test: "xx",
+            test2: "bdc",
+        }
+    });
+
+    let res = mock.mockResponse();
+
+    test("save survey with password", () => {
+        return surveyApi.saveSurvey(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+            });
+    });
+});
+
+describe("search survey", () => {
+    let req = mock.mockRequest({}, {});
+    req.signedCookies = [];
+    req.signedCookies['userid'] = "24";
+    req.params = {
+        ownerid: "24"
+    }
+
+    req.query = {
+        page: 1,
+        per_page: 1
+    }
+
+    let res = mock.mockResponse();
+
+    test("search survey by owner Id", () => {
+        return surveyApi.getAllSurveysByOwnerId(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+                let r = res.json();
+                expect(r.per_page).toBe(req.query.per_page);
+                expect(r.page).toBe(req.query.page);
+                expect(r.total !== 'undefined').toBe(true);
+            });
+    });
+
+});
+
+describe("search a survey", () => {
+    let req = mock.mockRequest({}, {});
+    req.params = {
+        surveyId: "1"
+    };
+
+    req.query = {
+        uid: "24",
+        v: "1"
+    };
+
+    let res = mock.mockResponse();
+
+    test("search survey by surveyid = 1", () => {
+        return surveyApi.getSurveyById(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+                let r = res.json();
+                console.log(r);
+                const d = r.data;
+                expect(d.surveyid).toBe(req.params.surveyId);
+                expect(d.version).toBe(req.query.v);
+                expect(d.userid).toBe(req.query.uid);
+                expect(d.name).toBe("test");
+                expect(d.pages.test).toBe("xx");
+                expect(d.pages.test2).toBe("bdc");
+            });
+    });
+
+});
+
+describe("rename a survey", () => {
+    let req = mock.mockRequest({}, {});
+    req.signedCookies = [];
+    req.signedCookies['userid'] = "24";
+
+    req.body.surveyid = '1';
+    req.body.version = '1';
+    req.body.name = "test";
+    
+    let res = mock.mockResponse();
+
+    test("rename a survey with surveyid = 1", () => {
+        return surveyApi.renameSurvey(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+                let r = res.json();
+                console.log(r);
+                const d = r.data;
+                expect(d.affected).toBe(1);
+            });
+    });
+
+});
+
+describe("remove a survey", () => {
+    let req = mock.mockRequest({}, {});
+    req.signedCookies = [];
+    req.signedCookies['userid'] = "24";
+
+    req.body.surveyid = '1';
+    req.body.version = '1';
+    
+    let res = mock.mockResponse();
+
+    test("remove a survey with surveyid = 1", () => {
+        return surveyApi.deleteSurvey(req, res)
+            .then(b => {
+                expect(b).toBe(true);
+                let r = res.json();
+                console.log(r);
+                const d = r.data;
+                expect(d.affected).toBe(1);
+            });
+    });
+
+});
+


### PR DESCRIPTION
- Support Secure Survey
- Change to MVC

----

### Details

* ต้องใส่ password ตอน __**ก่อนทำแบบสำรวจ**__
* ผู้ใช้ใส่ password ในหน้า edit แบบสอบถาม
* ต้องแสดง password ให้เห็นได้
* ต้อง แนบ password ไปใน json object 
* ต้องมีหน้า check password ก่อน แล้วค่อย redirect ไป 

### Example

POST /api/v2/admin/surveys

```JSON
{
	"userid": "1",
	"name": "my firt survey",
	"surveyid": "abc1234f",
	"version": "1",
	"password": "1234", //default is null
	"pages": {
		"Q1": "Do you have a girl friend?",
		"Q2": "Do you have a car?",
		"Q4": "Do you have a pet?"
	}
}
```

GET /api/v2/admin/surveys/owner/1

```
{
	"userid": "1",
	"name": "my firt survey",
	"surveyid": "abc1234f",
	"version": "1",
        "password_enable": true,
	"pages": {
		"Q1": "Do you have a girl friend?",
		"Q2": "Do you have a car?",
		"Q4": "Do you have a pet?"
	}
}
```


* ต้องหน้ากรอก password 
* มี API การเช็ค password แล้ว redirect 

* ต้องเพิ่ม Attribute  password_enable มาให้เอง ถ้ามีการส่ง attribute password มา

### DOD
- ปรับ API /api/v2/admin/surveys ให้รองรับ password ได้
