### PR TITLE
support duplicate survey api

### DIFF
--- a/backend/components/v2/admin/index.js
+++ b/backend/components/v2/admin/index.js
@@ -44,7 +44,8 @@ const {saveSurvey,
     getAllResultsBySurveyId,
     getResultById,
     saveResult,
-    viewPassword} = require('./survey');
+    viewPassword,
+    duplicateSurvey} = require('./survey');
 
 router.use(function (req, res, next) {
     logger.info('calling users api ' + req.path);
@@ -144,5 +145,10 @@ router.post('/profile', users.updateProfile);
 
 // /api/v2/admin/survey/password
 router.get('/survey/password', viewPassword);
+
+// /api/v2/admin/survey/duplicate?sid=1&v=1
+router.post('/survey/duplicate', duplicateSurvey);
+
+
 
 module.exports = router;

--- a/backend/model/v2/survey.js
+++ b/backend/model/v2/survey.js
@@ -56,6 +56,22 @@ function findOneAndReplace(filter, survey) {
     return mongodb.insert(filter, data, appConf.surveyCollections.survey);
 }
 
+function insertOne(survey){
+
+    const data = {
+        userid: survey.userid,
+        name: survey.name,
+        surveyid: survey.surveyid,
+        version: survey.version,
+        password: survey.password,
+        password_enable: survey.password_enable,
+        pages: survey.pages,
+        created_at: survey.created_at,
+        modified_at: survey.created_at,
+    }  
+    return mongodb.insertOne(data, appConf.surveyCollections.survey);
+}
+
 function count(filter) {
     return mongodb.count(filter, appConf.surveyCollections.survey)
         .then(r => {
@@ -82,5 +98,6 @@ module.exports = {
     count,
     updateOne,
     removeOne,
-    findOne
+    findOne,
+    insertOne
 }

--- a/backend/test/v2/admin/survey.test.js
+++ b/backend/test/v2/admin/survey.test.js
@@ -122,7 +122,7 @@ describe("rename a survey", () => {
     req.body.surveyid = '1';
     req.body.version = '1';
     req.body.name = "test";
-    
+
     let res = mock.mockResponse();
 
     test("rename a survey with surveyid = 1", () => {
@@ -148,7 +148,7 @@ describe("view password", () => {
             sid: '1',
             v: '1'
         };
-        
+
         let res = mock.mockResponse();
         return surveyApi.viewPassword(req, res).then(response => {
             expect(response).toBe(true);
@@ -156,7 +156,7 @@ describe("view password", () => {
             expect(data.surveyid).toBe('1');
             expect(data.password).toBe('1234');
         });
-        
+
     })
 
     test("should display passord as '1234' with undefined version", () => {
@@ -166,7 +166,7 @@ describe("view password", () => {
         req.query = {
             sid: '1'
         };
-        
+
         let res = mock.mockResponse();
         return surveyApi.viewPassword(req, res).then(response => {
             expect(response).toBe(true);
@@ -174,18 +174,17 @@ describe("view password", () => {
             expect(data.surveyid).toBe('1');
             expect(data.password).toBe('1234');
         });
-        
+
     })
 
 
-    
+
     test("should alert return code 40000", () => {
         let req = mock.mockRequest({}, {});
         req.signedCookies = [];
         req.signedCookies['userid'] = "24";
-        req.query = {
-        };
-        
+        req.query = {};
+
         let res = mock.mockResponse();
         return surveyApi.viewPassword(req, res).then(response => {
             expect(response).toBe(false);
@@ -193,7 +192,29 @@ describe("view password", () => {
             expect(data.success).toBe(false);
             expect(data.code).toBe(40000);
         });
-        
+
+    })
+})
+
+describe("duplicate survey", () => {
+
+    test("should create new survey 'test_copy' ", () => {
+        let req = mock.mockRequest({}, {});
+        req.signedCookies = [];
+        req.signedCookies['userid'] = "24";
+        req.body = {
+            surveyid: '1',
+            version: '1'
+        };
+
+        let res = mock.mockResponse();
+        return surveyApi.duplicateSurvey(req, res).then(response => {
+            expect(response).toBe(true);
+            const data = res.json();
+            expect(data.success).toBe(true);
+            expect(data.code).toBe(20000);
+        });
+
     })
 })
 
@@ -214,7 +235,7 @@ describe("remove a survey", () => {
 
     req.body.surveyid = '1';
     req.body.version = '1';
-    
+
     let res = mock.mockResponse();
 
     test("remove a survey with surveyid = 1", () => {


### PR DESCRIPTION
### Details
- คัดลอกฟอร์มเดิม โดยเติม "_copy" เพิ่มไปในชื่อเดิม 
- แสดงอยู่บนสุด โดยที่ create และ modify date ต้องเป็นเวลาตอนที่ duplicate 
- สร้าง object id ของคำถามใหม่
- เพิ่มเป็น action command ขึ้นมาว่า "duplicate"

----

~~API: POST /api/v2/survey/duplicate?surveyid=${surveyid}[&v=1]~~

API: POST /api/v2/admin/survey/duplicate

request
{
surveyid: "1",
version: "1",
}

----

### DOD
 - คัดลอกฟอร์มเดิม โดยเติม "_copy" เพิ่มไปในชื่อเดิม 

----

[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6b6ee0dc6e93b44c5f7a)