### PR TITLE
support survey with authenticatoin

### DIFF
--- a/backend/components/v2/admin/survey.js
+++ b/backend/components/v2/admin/survey.js
@@ -528,7 +528,7 @@ async function viewPassword(req, res) {
         }
     } catch (err) {
         logger.error(`viewpassword error: ${err}`);
-        http.error(res, 500, 50002, err);
+        http.error(res, 500, 50002, err.toString());
         return false;
     }
 }
@@ -561,7 +561,9 @@ async function duplicateSurvey(req, res) {
     }
 
     try {
-        const old_survey = await surveyModel.findOne(filter, {_id: 0}, {});
+        const old_survey = await surveyModel.findOne(filter, {
+            _id: 0
+        }, {});
         if (old_survey.length > 0 && old_survey[0].surveyid !== undefined && old_survey[0].name !== undefined) {
             old_survey[0].surveyid = uuidv4();
             old_survey[0].name = old_survey[0].name + '_copy';
@@ -584,7 +586,7 @@ async function duplicateSurvey(req, res) {
         }
     } catch (err) {
         logger.error(`duplicate survey error: ${err}`);
-        http.error(res, 500, 50002, err);
+        http.error(res, 500, 50002, err.toString());
         return false;
     }
 }

--- a/backend/components/v2/users/index.js
+++ b/backend/components/v2/users/index.js
@@ -33,7 +33,7 @@ const uuidv4 = require('uuid/v4');
 const {register} = require('./register');
 const {getMinistries, getDepartments, getOrganizations, getPrefixes} = require('./organization');
 const {sendOTP, resetPassword} = require('../users/password');
-const {getSurveyById, saveResult} = require('./survey');
+const {getSurveyById, saveResult, authSurvey} = require('./survey');
 
 router.use(function (req, res, next) {
     logger.info('calling users api ' + req.path);
@@ -90,5 +90,8 @@ router.post('/password/reset', resetPassword);
 
 // /api/v2/users/prefixes
 router.get('/prefixes', getPrefixes);
+
+// /api/v2/users/survey/auth
+router.post('/survey/auth', authSurvey);
 
 module.exports = router;

--- a/backend/test/v2/admin/survey.test.js
+++ b/backend/test/v2/admin/survey.test.js
@@ -3,7 +3,7 @@ global.appRoot = path.resolve(__dirname);
 const appConf = require('../../../config/production.conf');
 const mock = require("../../mock");
 const surveyApi = require("../../..//components/v2/admin/survey");
-
+const userApi = require("../../..//components/v2/users/survey");
 
 describe("create survey", () => {
 
@@ -219,6 +219,27 @@ describe("duplicate survey", () => {
 })
 
 
+describe("survey authentication", () => {
+
+    test("should ok if password = '1234' for survey id = '1'", () => {
+        let req = mock.mockRequest({}, {});
+        req.body = {
+            userid: '24',
+            password: '1234',
+            surveyid: '1',
+            version: '1'
+        };
+        let res = mock.mockResponse();
+
+        return userApi.authSurvey(req, res).then(response => {
+            expect(response).toBe(true);
+            const data = res.json();
+            expect(data.success).toBe(true);
+            expect(data.code).toBe(20000);
+        });
+
+    })
+})
 
 
 


### PR DESCRIPTION
### Details 

- เพิ่มการ authenticate สำหรับ แบบสอบถามที่ระบุรหัสผ่าน

POST ~~/api/v2/survey/auth~~ to /api/v2/users/survey/auth

request

``` 
{
	"surveyid": "1",
	"userid": "24",
	"verrsion": "1", //optional
	"password": "123"
}

```

response 

```
{
    "success": true,
    "code": 20000,
    "desc": null
}
```

*** อาจจะต้องเพิ่ม capcha เช็คว่าเป็นคนเหรือป่าว 

### DOD 
- API POST ~~/api/v2/survey/auth~~ to /api/v2/users/survey/auth


----

postman: 

[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6b6ee0dc6e93b44c5f7a)
